### PR TITLE
Relax pandas dependency from ==1.5.3 to >=1.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
         "Source": "https://github.com/protocol/pystarboard",
     },
     packages=["pystarboard"],
-    install_requires=["numpy>=1.22", "pandas==1.5.3", "requests>=2.28"],
+    install_requires=["numpy>=1.22", "pandas>=1.5.3", "requests>=2.28"],
     python_requires=">=3.8",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Relax pandas dependency from `==1.5.3` to `>=1.5.3`
This PR updates the `install_requires` section in `setup.py`:

```diff
-    install_requires=["numpy>=1.22", "pandas==1.5.3", "requests>=2.28"],
+    install_requires=["numpy>=1.22", "pandas>=1.5.3", "requests>=2.28"],
```


